### PR TITLE
adding timing utilities to file (recording) and tree (aggregating)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ flat list of all the files **up** the entire dependency chain.
 
 If `options.objects` is set, the returned list will be `File` objects.
 
+### Tree#timing()
+
+Aggregates all the timers for all files in the tree. These stats are useful when trying to figure
+out which plugins/hooks are taking up the most time so they can hopefully be optimized.
+
+### Tree#size()
+
+Returns the number of files in the tree.
+
 ### Tree#clone()
 
 Returns a new `Tree` object that is an effective clone of the original.
@@ -214,6 +223,21 @@ Can be used by the `prewrite` hook to mark a file as "dirty" so that it should b
 For example, [mako-stat](http://github.com/makojs/stat) will use this method whenever the
 modification time for a file has changed, which indicates to mako that analyze needs to be run
 again for this file.
+
+### File#time(label)
+
+Start a timer using the given `label` to describe what is being timed. (eg: "read", "babel")
+For simple hooks/plugins, a single timer is all you need.
+
+If a plugin wants to have multiple timers, it should use it's name as a prefix. (eg: "js:pack",
+"css:dependencies")
+
+### File#timeEnd(label)
+
+Stops the timer using the given `label`.
+
+The value saved here will be aggregated by the tree to give a glimpse of the overall time spent
+by varying plugins.
 
 ### File#clone(tree)
 

--- a/lib/file.js
+++ b/lib/file.js
@@ -28,6 +28,8 @@ class File {
     this.entry = !!entry;
     this.tree = tree;
     this.analyzing = false;
+    this.timers = new Map();
+    this.timing = new Map();
     this.dirty();
   }
 
@@ -114,6 +116,31 @@ class File {
   }
 
   /**
+   * Starts a timer for this file using the given `label`.
+   *
+   * @param {String} label  The thing is being timed (eg: "stat", "read")
+   * @return {Array}        The start hrtime (ie: [sec, nsec])
+   */
+  time(label) {
+    let start = process.hrtime();
+    this.timers.set(label, start);
+    return start;
+  }
+
+  /**
+   * Ends a timer for this file using the given `label`.
+   *
+   * @param {String} label  The thing is being timed (eg: "stat", "read")
+   * @return {Array}        The duration hrtime (ie: [sec, nsec])
+   */
+  timeEnd(label) {
+    let prev = this.timers.get(label);
+    let diff = process.hrtime(prev);
+    this.timing.set(label, diff);
+    return diff;
+  }
+
+  /**
    * Create a clone of this instance.
    *
    * @param {Tree} tree  The new build tree to attach the clone to.
@@ -123,6 +150,8 @@ class File {
     let file = new File(this.path);
     Object.assign(file, this);
     file.tree = tree;
+    file.timers = new Map(file.timers.entries());
+    file.timing = new Map(file.timing.entries());
     return file;
   }
 }

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -241,6 +241,25 @@ class Tree {
   }
 
   /**
+   * Combine all the timing maps for all the files in the tree into a single
+   * map to use for stats reporting.
+   *
+   * @return {Map}
+   */
+  timing() {
+    return this.getFiles({ objects: true }).reduce(function (acc, file) {
+      Array.from(file.timing.entries()).forEach(function (entry) {
+        let key = entry[0];
+        let value = entry[1];
+        let current = acc.has(key) ? acc.get(key) : [ 0, 0 ];
+        acc.set(key, add(current, value));
+      });
+
+      return acc;
+    }, new Map());
+  }
+
+  /**
    * Tells us how large the underlying graph is.
    *
    * @return {Number}
@@ -299,4 +318,15 @@ function vertices(value) {
   return function (vertex) {
     return value ? vertex[1] : vertex[0];
   };
+}
+
+/**
+ * Add 2 hrtime values together.
+ *
+ * @param {Array} a  The first hrtime value.
+ * @param {Array} b  The second hrtime value.
+ * @return {Array}   The added hrtime value.
+ */
+function add(a, b) {
+  return [ a[0] + b[0], a[1] + b[1] ];
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "eslint": "^1.3.1",
     "eslint-plugin-mocha": "^1.1.0",
     "eslint-plugin-require-path-exists": "^1.0.15",
-    "mocha": "^2.3.0"
+    "mocha": "^2.3.0",
+    "monkeypatch": "^1.0.0"
   },
   "scripts": {
     "lint": "eslint .",

--- a/test/file.js
+++ b/test/file.js
@@ -3,6 +3,7 @@
 
 let assert = require('chai').assert;
 let File = require('../lib/file');
+let monkeypatch = require('monkeypatch');
 let Tree = require('../lib/tree');
 
 describe('File()', function () {
@@ -166,6 +167,84 @@ describe('File()', function () {
     });
   });
 
+  describe('#time(label)', function () {
+    afterEach(function () {
+      if (process.hrtime.unpatch) process.hrtime.unpatch();
+    });
+
+    it('should return the current time', function () {
+      let hrtime = [ 123, 456 ];
+      monkeypatch(process, 'hrtime', () => hrtime);
+
+      let file = new File('index.txt');
+      assert.deepEqual(file.time('test'), hrtime);
+    });
+
+    it('should save the current time in timers', function () {
+      let hrtime = [ 123, 456 ];
+      monkeypatch(process, 'hrtime', () => hrtime);
+
+      let file = new File('index.txt');
+      file.time('test');
+      assert.deepEqual(file.timers.get('test'), hrtime);
+    });
+
+    it('should overwrite the current time when called multiple times', function () {
+      let x = 0;
+      let hrtimes = [ [ 123, 456 ], [ 246, 357 ] ];
+      monkeypatch(process, 'hrtime', () => hrtimes[x++]);
+
+      let file = new File('index.txt');
+      file.time('test');
+      file.time('test');
+      assert.deepEqual(file.timers.get('test'), hrtimes[1]);
+    });
+  });
+
+  describe('#timeEnd(label)', function () {
+    afterEach(function () {
+      if (process.hrtime.unpatch) process.hrtime.unpatch();
+    });
+
+    it('should return the elapsed time', function () {
+      monkeypatch(process, 'hrtime', function (original, start) {
+        if (start) return [ 0, 25 ];
+        return [ 123, 456 ];
+      });
+
+      let file = new File('index.txt');
+      file.time('test');
+      assert.deepEqual(file.timeEnd('test'), [ 0, 25 ]);
+    });
+
+    it('should save the elapsed time in timing', function () {
+      monkeypatch(process, 'hrtime', function (original, start) {
+        if (start) return [ 0, 25 ];
+        return [ 123, 456 ];
+      });
+
+      let file = new File('index.txt');
+      file.time('test');
+      file.timeEnd('test');
+      assert.deepEqual(file.timing.get('test'), [ 0, 25 ]);
+    });
+
+    it('should overwrite the elapsed time when called multiple times', function () {
+      let x = 0;
+      let difftimes = [ [ 0, 25 ], [ 1, 50 ] ];
+      monkeypatch(process, 'hrtime', function (original, start) {
+        if (start) return difftimes[x++];
+        return [ 123, 456 ];
+      });
+
+      let file = new File('index.txt');
+      file.time('test');
+      file.timeEnd('test');
+      file.timeEnd('test');
+      assert.deepEqual(file.timing.get('test'), difftimes[1]);
+    });
+  });
+
   describe('#clone(tree)', function () {
     it('should create a new copy of the file', function () {
       let tree1 = new Tree();
@@ -205,6 +284,30 @@ describe('File()', function () {
       let a2 = a1.clone(tree2);
 
       assert.strictEqual(a2.tree, tree2);
+    });
+
+    it('should clone the timing maps', function () {
+      let x = 0;
+      let y = 1;
+      monkeypatch(process, 'hrtime', function (original, start) {
+        if (start) return [ 1 * x++, 25 * y++ ];
+        return [ x, y * 1000 ];
+      });
+
+      let tree1 = new Tree();
+      let a1 = tree1.addFile('a');
+      a1.time('test');
+      a1.timeEnd('test');
+      let tree2 = new Tree();
+      let a2 = a1.clone(tree2);
+
+      assert.notStrictEqual(a2.timers, a1.timers);
+      assert.notStrictEqual(a2.timing, a1.timing);
+
+      assert.deepEqual(a2.timers.get('test'), [ 0, 1000 ]);
+      assert.deepEqual(a2.timing.get('test'), [ 0, 25 ]);
+
+      process.hrtime.unpatch();
     });
   });
 });

--- a/test/tree.js
+++ b/test/tree.js
@@ -3,6 +3,7 @@
 
 let assert = require('chai').assert;
 let File = require('../lib/file');
+let monkeypatch = require('monkeypatch');
 let Tree = require('../lib/tree');
 
 describe('Tree()', function () {
@@ -368,6 +369,79 @@ describe('Tree()', function () {
           tree.dependantsOf('d', { objects: true }).forEach(file => assert.instanceOf(file, File));
         });
       });
+    });
+  });
+
+  describe('#timing()', function () {
+    beforeEach(function () {
+      let x = 0;
+      let y = 1;
+
+      monkeypatch(process, 'hrtime', function (original, start) {
+        if (start) return [ 1 * x++, 25 * y++ ];
+        return true;
+      });
+    });
+
+    afterEach(function () {
+      process.hrtime.unpatch();
+    });
+
+    it('should collect the timing from a single file', function () {
+      let tree = new Tree();
+      let a = tree.addFile('a');
+      a.time('test');
+      a.timeEnd('test');
+
+      let timing = tree.timing();
+      assert.deepEqual(timing.get('test'), [ 0, 25 ]); // [0,25]
+    });
+
+    it('should aggregate the timing from multiple files', function () {
+      let tree = new Tree();
+      let a = tree.addFile('a');
+      let b = tree.addFile('b');
+      let c = tree.addFile('c');
+      a.time('test');
+      a.timeEnd('test');
+      b.time('test');
+      b.timeEnd('test');
+      c.time('test');
+      c.timeEnd('test');
+
+      let timing = tree.timing();
+      assert.deepEqual(timing.get('test'), [ 3, 150 ]); // [0,25] + [1,50] + [2,75]
+    });
+
+    it('should not mix labels', function () {
+      let tree = new Tree();
+      let a = tree.addFile('a');
+      let b = tree.addFile('b');
+      a.time('test');
+      a.timeEnd('test');
+      b.time('test');
+      b.timeEnd('test');
+      a.time('another');
+      a.timeEnd('another');
+
+      let timing = tree.timing();
+      assert.deepEqual(timing.get('test'), [ 1, 75 ]);    // [0,25] + [1,50]
+      assert.deepEqual(timing.get('another'), [ 2, 75 ]); // [2,75]
+    });
+  });
+
+  describe('#size()', function () {
+    // a <- b
+    //   <- c
+    let tree = new Tree();
+    tree.addFile('a');
+    tree.addFile('b');
+    tree.addFile('c');
+    tree.addDependency('a', 'b');
+    tree.addDependency('a', 'c');
+
+    it('should return the number of files in the tree', function () {
+      assert.strictEqual(tree.size(), 3);
     });
   });
 


### PR DESCRIPTION
Now that I'm wanting to optimize mako, I want to be able to collect timing stats from the various hooks/plugins.

A flamegraph of the entire build is useful to locate CPU bottlenecking, which I plan on using soon. This will help to point out how long the various async operations take. (of course these timing utils can also be used for measuring sync operations too)