### PR TITLE
adding to/from string methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,17 @@ file marked as an entry.
 If `entries` is passed, (must be an `Array`) then any files that cannot reach _those_ files will
 be removed from the graph. (essentially overrides the internal list of entries)
 
+### Tree#toString([space])
+
+Serializes the tree into a JSON string, which can be written to disk (and then read back) to help
+reduce the amount of duplicate work between different runs of mako.
+
+The `space` parameter is there if you want to "pretty-print" the JSON output.
+
+### Tree.fromString(input)
+
+Unserializes a JSON string into a `Tree` instance.
+
 ### File(location, tree, [entry]) *(constructor)*
 
 Each instance represents a file in the overall build. The `location` is an absolute path, `tree`

--- a/lib/file.js
+++ b/lib/file.js
@@ -3,6 +3,7 @@
 
 let debug = require('debug')('mako-file');
 let extension = require('file-extension');
+let iso = require('regex-iso-date')();
 let path = require('path');
 
 const pwd = process.cwd();
@@ -160,8 +161,65 @@ class File {
     debug('done cloning file', relative(this.path));
     return file;
   }
+
+  /**
+   * Returns a trimmed object that can be serialized as JSON. It strips the tree
+   * link and includes all other properties, including the custom ones.
+   *
+   * @return {File}
+   */
+  toJSON() {
+    return this.clone(null);
+  }
+
+  /**
+   * Serializes the file into a plain JSON string for writing to storage.
+   * (probably disk)
+   *
+   * @param {Number} space  The JSON.stringify space parameter.
+   * @return {String}
+   */
+  toString(space) {
+    return JSON.stringify(this, null, space);
+  }
+
+  /**
+   * Used to parse a string value into a usable file.
+   *
+   * @static
+   * @param {String} input  The raw JSON string to parse.
+   * @param {Tree} tree     The tree to associate this file with.
+   * @return {File}
+   */
+  static fromString(input, tree) {
+    let o = JSON.parse(input, reviver);
+    let file = new File(o.path, null, o.entry);
+    Object.assign(file, o);
+    file.tree = tree;
+    return file;
+  }
 }
 
 
 // single export
 module.exports = File;
+
+
+/**
+ * JSON.parse reviver param for restoring buffers and dates to file objects.
+ *
+ * @param {String} key    See JSON.parse reviver documentation
+ * @param {String} value  See JSON.parse reviver documentation
+ * @return {Mixed}
+ */
+function reviver(key, value) {
+  if (value && value.type === 'Buffer') {
+    return new Buffer(value.data);
+  }
+
+  if (typeof value === 'string' && iso.test(value)) {
+    return new Date(value);
+  }
+
+  return value;
+}

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -335,6 +335,58 @@ class Tree {
 
     debug('done pruning tree');
   }
+
+  /**
+   * Returns a trimmed object that can be serialized as JSON. It includes a list
+   * of vertices and edges for reconstructing the underlying graph.
+   *
+   * @return {Object}
+   */
+  toJSON() {
+    let vertices = [];
+    for (let vertex of this.graph.vertices()) {
+      vertices.push([ vertex[0], vertex[1].toString() ]);
+    }
+
+    let edges = [];
+    for (let edge of this.graph.edges()) {
+      edges.push([ edge[0], edge[1] ]);
+    }
+
+    return { vertices: vertices, edges: edges };
+  }
+
+  /**
+   * Serializes the tree into a plain JSON string for writing to storage.
+   * (probably disk)
+   *
+   * @param {Number} space  The JSON.stringify space parameter.
+   * @return {String}
+   */
+  toString(space) {
+    return JSON.stringify(this, null, space);
+  }
+
+  /**
+   * Used to parse a string value into a usable tree.
+   *
+   * @static
+   * @param {String} input  The raw JSON string to parse.
+   * @return {Tree}
+   */
+  static fromString(input) {
+    let tree = new Tree();
+    let parsed = JSON.parse(input);
+
+    parsed.vertices.forEach(v => {
+      tree.graph.addNewVertex(v[0], File.fromString(v[1], tree));
+    });
+    parsed.edges.forEach(e => {
+      tree.graph.addNewEdge(e[0], e[1]);
+    });
+
+    return tree;
+  }
 }
 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "defaults": "^1.0.3",
     "file-extension": "^2.0.1",
     "graph-toposort": "^0.1.1",
-    "graph.js": "^1.20.1"
+    "graph.js": "^1.20.1",
+    "regex-iso-date": "^1.0.0"
   },
   "devDependencies": {
     "@dominicbarnes/eslint-config": "^0.2.1",

--- a/test/file.js
+++ b/test/file.js
@@ -254,4 +254,93 @@ describe('File()', function () {
       assert.strictEqual(a2.tree, tree2);
     });
   });
+
+  describe('#toJSON()', function () {
+    it('should return a cloned object', function () {
+      let tree = new Tree();
+      let a = tree.addFile('a.txt', true);
+      assert.notStrictEqual(a.toJSON(), a);
+    });
+
+    it('should preserve internal properties', function () {
+      let tree = new Tree();
+      let a = tree.addFile('a.txt', true);
+      a.contents = 'hello world';
+      let actual = a.toJSON();
+      assert.strictEqual(actual.path, 'a.txt');
+      assert.strictEqual(actual.type, 'txt');
+      assert.isTrue(actual.entry);
+      assert.isFalse(actual.analyzing);
+      assert.isFalse(actual.analyzed);
+    });
+
+    it('should preserve custom properties', function () {
+      let tree = new Tree();
+      let a = tree.addFile('a.txt', true);
+      a.contents = 'hello world';
+      let actual = a.toJSON();
+      assert.strictEqual(actual.contents, 'hello world');
+    });
+
+    it('should strip out the tree property', function () {
+      let tree = new Tree();
+      let a = tree.addFile('a.txt', true);
+      assert.isNull(a.toJSON().tree);
+    });
+  });
+
+  describe('#toString([space])', function () {
+    it('should completely stringify to JSON', function () {
+      let file = new File('a.txt', null, true);
+      assert.deepEqual(JSON.parse(file.toString()), {
+        path: 'a.txt',
+        type: 'txt',
+        entry: true,
+        analyzing: false,
+        analyzed: false,
+        tree: null
+      });
+    });
+  });
+
+  describe('.fromString(input, tree)', function () {
+    it('should parse a JSON string into a file instance', function () {
+      let file = new File('a.txt', null, true);
+
+      let actual = File.fromString(file.toString());
+      assert.instanceOf(actual, File);
+      assert.strictEqual(actual.path, 'a.txt');
+      assert.strictEqual(actual.type, 'txt');
+      assert.isTrue(actual.entry);
+      assert.isFalse(actual.analyzing);
+      assert.isFalse(actual.analyzed);
+    });
+
+    it('should properly handle date objects', function () {
+      let now = new Date();
+      let file = new File('a.txt', null, true);
+      file.modified = now;
+
+      let actual = File.fromString(file.toString());
+      assert.instanceOf(actual.modified, Date);
+      assert.strictEqual(actual.modified.getTime(), now.getTime());
+    });
+
+    it('should properly handle buffer objects', function () {
+      let file = new File('a.txt', null, true);
+      file.contents = new Buffer('hello world');
+
+      let actual = File.fromString(file.toString());
+      assert.isTrue(Buffer.isBuffer(actual.contents));
+      assert.strictEqual(actual.contents.toString(), 'hello world');
+    });
+
+    it('should set the tree property', function () {
+      let tree = new Tree();
+      let file = tree.addFile('a.txt', true);
+
+      let actual = File.fromString(file.toString(), tree);
+      assert.strictEqual(actual.tree, tree);
+    });
+  });
 });

--- a/test/tree.js
+++ b/test/tree.js
@@ -594,4 +594,62 @@ describe('Tree()', function () {
       });
     });
   });
+
+  describe('#toJSON()', function () {
+    it('should return a list of vertices and edges for reconstructing the graph', function () {
+      // a <- b
+      let tree = new Tree();
+      let a = tree.addFile('a', true);
+      let b = tree.addFile('b');
+      tree.addDependency('a', 'b');
+
+      assert.deepEqual(tree.toJSON(), {
+        vertices: [
+          [ 'a', a.toString() ],
+          [ 'b', b.toString() ]
+        ],
+        edges: [
+          [ 'b', 'a' ]
+        ]
+      });
+    });
+  });
+
+  describe('#toString([space])', function () {
+    it('should completely stringify to JSON', function () {
+      // a <- b
+      let tree = new Tree();
+      let a = tree.addFile('a', true);
+      let b = tree.addFile('b');
+      tree.addDependency('a', 'b');
+
+      assert.strictEqual(tree.toString(), JSON.stringify({
+        vertices: [
+          [ 'a', a.toString() ],
+          [ 'b', b.toString() ]
+        ],
+        edges: [
+          [ 'b', 'a' ]
+        ]
+      }));
+    });
+  });
+
+  describe('.fromString()', function () {
+    it('should parse a JSON string into a tree instance', function () {
+      // a <- b
+      let tree = new Tree();
+      tree.addFile('a', true);
+      tree.addFile('b');
+      tree.addDependency('a', 'b');
+
+      let actual = Tree.fromString(tree.toString());
+      assert.instanceOf(actual, Tree);
+      assert.isTrue(actual.graph.equals(tree.graph, eqV, () => true));
+
+      function eqV(a, b) {
+        return a.path === b.path;
+      }
+    });
+  });
 });


### PR DESCRIPTION
This fixes #3 by adding a `Tree#toString()` and `Tree.fromString()` to the public API. This is the precursor to allowing mako builds to save their tree to disk so it doesn't need to be re-traversed for every startup.