### PR TITLE
tree#removeFile(file) should remove vertex and all edges connected to that vertex

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -98,7 +98,7 @@ class Tree {
    */
   removeFile(location) {
     debug('removing node %s', relative(location));
-    this.graph.removeVertex(location);
+    this.graph.destroyExistingVertex(location);
   }
 
   /**

--- a/test/tree.js
+++ b/test/tree.js
@@ -122,16 +122,17 @@ describe('Tree()', function () {
       assert.isFalse(tree.hasFile('a'));
     });
 
-    it('should fail if there are still dependencies defined', function () {
+    it('should remove the vertex and cleanup all connected edges', function () {
       // a <- b
       let tree = new Tree();
       tree.addFile('a');
       tree.addFile('b');
       tree.addDependency('a', 'b');
 
-      assert.throws(function () {
-        tree.removeFile('a');
-      });
+      tree.removeFile('a');
+      assert.isUndefined(tree.getFile('a'));
+      assert.isFalse(tree.hasDependency('a', 'b'));
+      assert.isFalse(tree.hasDependant('b', 'a'));
     });
   });
 


### PR DESCRIPTION
This change causes `tree#removeFile()` to no longer throw when there are still connected edges, but instead cleanup those edges.

This will fix the errors you'd get with cycles in mako-js. I've tested it in an app where there are cycles. I *think* this is safe to do, but I haven't spent a lot of time considering the impact of this change.

I certainly don't think plugins should be responsible for cycle cleanup, but I'm not 100% sure if this is the right solution or not.