### PR TITLE
adding ability to forcibly remove a file from the tree

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -94,11 +94,20 @@ class Tree {
   /**
    * Remove the file at the given `location` from the graph.
    *
-   * @param {String} location  The absolute path to the file.
+   * Available `options`:
+   *  - `force` removes the file even if dependencies/dependants exist
+   *
+   * @param {String} location   The absolute path to the file.
+   * @param {Object} [options]  Additional options.
    */
-  removeFile(location) {
-    debug('removing node %s', relative(location));
-    this.graph.removeVertex(location);
+  removeFile(location, options) {
+    let config = defaults(options, { force: false });
+    debug('removing node %s: %j', relative(location), config);
+    if (config.force) {
+      this.graph.destroyVertex(location);
+    } else {
+      this.graph.removeVertex(location);
+    }
   }
 
   /**

--- a/test/tree.js
+++ b/test/tree.js
@@ -113,7 +113,7 @@ describe('Tree()', function () {
     });
   });
 
-  describe('#removeFile(location)', function () {
+  describe('#removeFile(location, [options])', function () {
     it('should remove the file from the tree', function () {
       let tree = new Tree();
       tree.addFile('a');
@@ -131,6 +131,20 @@ describe('Tree()', function () {
 
       assert.throws(function () {
         tree.removeFile('a');
+      });
+    });
+
+    context('with options', function () {
+      context('.force', function () {
+        // a <- b
+        let tree = new Tree();
+        tree.addFile('a');
+        tree.addFile('b');
+        tree.addDependency('a', 'b');
+
+        tree.removeFile('a', { force: true });
+        assert.isFalse(tree.hasFile('a'));
+        assert.isTrue(tree.hasFile('b'));
       });
     });
   });
@@ -555,7 +569,7 @@ describe('Tree()', function () {
       assert.deepEqual(tree.getFiles({ topological: true }), [ 'c', 'b', 'a' ]);
     });
 
-    it('should not properly handle a complex case', function () {
+    it('should properly handle a complex case', function () {
       // a* <- b <- c <- d
       // e  <- f <-
       let tree = new Tree();
@@ -635,7 +649,7 @@ describe('Tree()', function () {
     });
   });
 
-  describe('.fromString()', function () {
+  describe('.fromString(input)', function () {
     it('should parse a JSON string into a tree instance', function () {
       // a <- b
       let tree = new Tree();


### PR DESCRIPTION
This adds `options.force` to `Tree#removeFile()`, preserving the current behavior by default.

This is primarily meant to address cycles in graphs, which make the current behavior of tools like `mako-js` and `mako-css` break down. (see #5)

/cc @matthewmueller 