### PR TITLE
The initial refactor to using Vinyl

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -3,10 +3,8 @@
 
 let debug = require('debug')('mako-file');
 let extension = require('file-extension');
-let path = require('path');
-
-const pwd = process.cwd();
-const relative = abs => path.relative(pwd, abs);
+let uuid = require('uuid');
+let Vinyl = require('vinyl');
 
 
 /**
@@ -14,41 +12,45 @@ const relative = abs => path.relative(pwd, abs);
  *
  * @class
  */
-class File {
+class File extends Vinyl {
   /**
    * Sets up the instance.
    *
-   * @param {String} location  The absolute path to the file.
+   * @param {Object} params    The vinyl params for this file.
    * @param {Tree} tree        The parent build tree.
    * @param {Boolean} [entry]  If the file is an entry file.
    */
-  constructor(location, tree, entry) {
-    debug('initialize %s', relative(location));
-    this.path = location;
+  constructor(params, tree, entry) {
+    if (typeof params === 'string') {
+      super({ path: params });
+    } else {
+      super(params);
+    }
+    this.id = uuid.v4();
     this.entry = !!entry;
     this.tree = tree;
-    this.analyzing = false;
-    this.dirty();
   }
 
   /**
-   * Tells us if the file is an entry.
+   * Check to see if this file has the given path currently. (or did at some
+   * point in it's history)
    *
+   * @param {String} path  The absolute path to search for.
    * @return {Boolean}
    */
-  isEntry() {
-    return !!this.entry;
+  hasPath(path) {
+    return this.path === path || this.history.indexOf(path) > -1;
   }
 
   /**
    * Check to see if the `child` file is a dependency of this file.
    *
    * @see Tree#hasDependency()
-   * @param {String} child  The absolute path to the dependency.
+   * @param {String} child  The file ID of the dependency.
    * @return {Boolean}
    */
   hasDependency(child) {
-    return this.tree.hasDependency(this.path, child);
+    return this.tree.hasDependency(this.id, child);
   }
 
   /**
@@ -56,21 +58,20 @@ class File {
    * instance.
    *
    * @see Tree#addDependency()
-   * @param {String} child  The absolute path to the dependency.
-   * @return {File}
+   * @param {String} child  The file ID of the dependency.
    */
   addDependency(child) {
-    return this.tree.addDependency(this.path, child);
+    this.tree.addDependency(this.id, child);
   }
 
   /**
    * Removes the `child` as a dependency of this file.
    *
    * @see Tree#removeDependency()
-   * @param {String} child  The absolute path to the dependency.
+   * @param {String} child  The file ID of the dependency.
    */
   removeDependency(child) {
-    this.tree.removeDependency(this.path, child);
+    this.tree.removeDependency(this.id, child);
   }
 
   /**
@@ -81,18 +82,18 @@ class File {
    * @return {Array}
    */
   dependencies(options) {
-    return this.tree.dependenciesOf(this.path, options);
+    return this.tree.dependenciesOf(this.id, options);
   }
 
   /**
    * Check to see if the `parent` file is a dependant of this file.
    *
    * @see Tree#hasDependant()
-   * @param {String} parent  The absolute path to the dependant.
+   * @param {String} parent  The file ID of the dependant.
    * @return {Boolean}
    */
   hasDependant(parent) {
-    return this.tree.hasDependant(this.path, parent);
+    return this.tree.hasDependant(this.id, parent);
   }
 
   /**
@@ -100,21 +101,20 @@ class File {
    * instance.
    *
    * @see Tree#addDependant()
-   * @param {String} parent  The absolute path to the dependant.
-   * @return {File}
+   * @param {String} parent  The file ID of the dependant.
    */
   addDependant(parent) {
-    return this.tree.addDependant(this.path, parent);
+    this.tree.addDependant(this.id, parent);
   }
 
   /**
    * Removes the `parent` as a dependant of this file.
    *
    * @see Tree#removeDependant()
-   * @param {String} parent  The absolute path to the dependant.
+   * @param {String} parent  The file ID of the dependant.
    */
   removeDependant(parent) {
-    this.tree.removeDependant(this.path, parent);
+    this.tree.removeDependant(this.id, parent);
   }
 
   /**
@@ -125,15 +125,42 @@ class File {
    * @return {Array}
    */
   dependants(options) {
-    return this.tree.dependantsOf(this.path, options);
+    return this.tree.dependantsOf(this.id, options);
   }
 
   /**
    * Flags the file so it will be analyzed by mako.
    */
   dirty() {
-    this.type = this.initialType();
     this.analyzed = false;
+    this.history.splice(1); // remove all but original path
+  }
+
+  /**
+   * Retrieves the current type for the file.
+   *
+   * @return {String}
+   */
+  get type() {
+    return extension(this.path);
+  }
+
+  /**
+   * Set the type/extension for this file.
+   *
+   * @param {String} type  The type (without the leading dot)
+   */
+  set type(type) {
+    this.extname = `.${type}`;
+  }
+
+  /**
+   * Gets the initial path for this file.
+   *
+   * @return {String}
+   */
+  get initialPath() {
+    return this.history[0];
   }
 
   /**
@@ -142,23 +169,8 @@ class File {
    *
    * @return {String}
    */
-  initialType() {
-    return extension(this.path);
-  }
-
-  /**
-   * Create a clone of this instance.
-   *
-   * @param {Tree} tree  The new build tree to attach the clone to.
-   * @return {File}
-   */
-  clone(tree) {
-    debug('cloning file', relative(this.path));
-    let file = new File(this.path);
-    Object.assign(file, this);
-    file.tree = tree;
-    debug('done cloning file', relative(this.path));
-    return file;
+  get initialType() {
+    return extension(this.initialPath);
   }
 
   /**
@@ -171,6 +183,15 @@ class File {
     let clone = this.clone(null);
     delete clone.tree;
     return clone;
+  }
+
+  /**
+   * Allow for easier logging.
+   *
+   * @return {String}
+   */
+  toString() {
+    return this.inspect();
   }
 
   /**

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -8,11 +8,7 @@ let defaults = require('defaults');
 let File = require('./file');
 let iso = require('regex-iso-date')();
 let Graph = require('graph.js/dist/graph.js');
-let path = require('path');
 let toposort = require('graph-toposort');
-
-const pwd = process.cwd();
-const relative = abs => path.relative(pwd, abs);
 
 
 /**
@@ -30,41 +26,51 @@ class Tree {
   }
 
   /**
-   * Checks to see if the given `location` file exists in the graph.
+   * Checks to see if the given file ID exists in the tree.
    *
-   * @param {String} location  The absolute path to check for.
+   * @param {File|String} file  The file or string ID.
    * @return {Boolean}
    */
-  hasFile(location) {
-    return this.graph.hasVertex(location);
+  hasFile(file) {
+    return this.graph.hasVertex(id(file));
   }
 
   /**
-   * Adds a new file `location` to the graph. Specify `entry` if the file
-   * should be treated specially as an entry file. Returns the new `File`
-   * instance.
+   * Adds the file with the given `params` to the tree. If a file with that
+   * path already exists in the tree, that is returned instead.
    *
-   * @param {String} location  The absolute path to the file.
+   * @param {Object} params    The vinyl params for this file.
    * @param {Boolean} [entry]  Whether or not this file is an entry.
    * @return {File}
    */
-  addFile(location, entry) {
-    if (!this.hasFile(location)) {
-      debug('adding node: %s (entry: %j)', relative(location), !!entry);
-      let file = new File(location, this, !!entry);
-      this.graph.addNewVertex(location, file);
-    }
-    return this.getFile(location);
+  addFile(params, entry) {
+    let file = new File(params, this, entry);
+    debug('adding node: %s (entry: %j)', file, file.entry);
+    this.graph.addNewVertex(file.id, file);
+    return file;
   }
 
   /**
-   * Returns the `File` instance for the `location`.
+   * Returns the `File` with the given `id`.
    *
-   * @param {String} location  The absolute path to the file.
+   * @param {String} file  The file ID.
    * @return {File}
    */
-  getFile(location) {
-    return this.graph.vertexValue(location);
+  getFile(file) {
+    return this.graph.vertexValue(file);
+  }
+
+  /**
+   * Iterates through the files looking for one that matches the input path.
+   *
+   * @param {String} path  The absolute path to search for.
+   * @return {File}
+   */
+  findFile(path) {
+    for (let vertex of this.graph.vertices()) {
+      let file = vertex[1];
+      if (file.hasPath(path)) return file;
+    }
   }
 
   /**
@@ -72,55 +78,36 @@ class Tree {
    *
    * Available `options`:
    *  - `topological` sort the files topologically
-   *  - `objects` return the `File` instances
    *
    * @param {Object} [options]  The filter criteria.
    * @return {Array}
    */
   getFiles(options) {
-    let config = defaults(options, {
-      topological: false,
-      objects: false
-    });
-    debug('getting files: %j', config);
+    let config = defaults(options, { topological: false });
+    debug('getting %d files: %j', this.size(), config);
 
-    if (config.topological) {
-      let list = toposort(this.graph);
-      debug('%d files in tree', list.length);
-      return config.objects ? list.map(id => this.getFile(id)) : list;
-    }
-
-    debug('%d files in tree', this.size());
-    return Array.from(this.graph.vertices()).map(vertices(config.objects));
+    return config.topological
+      ? toposort(this.graph).map(id => this.getFile(id))
+      : Array.from(this.graph.vertices()).map(v => v[1]);
   }
 
   /**
-   * Remove the file at the given `location` from the graph.
+   * Remove the file with the given `id` from the graph.
    *
    * Available `options`:
    *  - `force` removes the file even if dependencies/dependants exist
    *
-   * @param {String} location   The absolute path to the file.
+   * @param {File|String} file  The file or string ID.
    * @param {Object} [options]  Additional options.
    */
-  removeFile(location, options) {
+  removeFile(file, options) {
     let config = defaults(options, { force: false });
-    debug('removing node %s: %j', relative(location), config);
+    debug('removing node %s: %j', id(file), config);
     if (config.force) {
-      this.graph.destroyVertex(location);
+      this.graph.destroyVertex(id(file));
     } else {
-      this.graph.removeVertex(location);
+      this.graph.removeVertex(id(file));
     }
-  }
-
-  /**
-   * Tells us whether or not the file at `location` is an entry.
-   *
-   * @param {String} location  The absolute path to the file.
-   * @return {Boolean}
-   */
-  isEntry(location) {
-    return !!this.getFile(location).isEntry();
   }
 
   /**
@@ -128,16 +115,12 @@ class Tree {
    *
    * Available `options`:
    *  - `from` only pull entries that are reachable from this file
-   *  - `objects` return the `File` instances
    *
    * @param {Object} [options]  The filter criteria.
    * @return {Array}
    */
   getEntries(options) {
-    let config = defaults(options, {
-      from: null,
-      objects: false
-    });
+    let config = defaults(options, { from: null });
     debug('getting entry files: %j', config);
 
     let entries = Array.from(this.graph.sinks())
@@ -145,61 +128,47 @@ class Tree {
 
     if (config.from) {
       entries = entries.filter(vertex => {
-        let start = config.from;
+        let start = id(config.from);
         let end = vertex[0];
         return start === end || this.graph.hasPath(start, end);
       });
     }
 
     debug('%d entries found', entries.length);
-    return entries.map(vertices(config.objects));
+    return entries.map(v => v[1]);
   }
 
   /**
    * Checks to see if the given `parent` has a link to dependency `child`.
    *
-   * @param {String} parent  The absolute path for the parent file.
-   * @param {String} child   The absolute path for the dependency file.
+   * @param {String|File} parent  The parent file (or it's string ID).
+   * @param {String|File} child   The child file (or it's string ID).
    * @return {Boolean}
    */
   hasDependency(parent, child) {
-    return this.graph.hasEdge(child, parent);
+    return this.graph.hasEdge(id(child), id(parent));
   }
 
   /**
    * Sets up the file `child` as a dependency of `parent`.
    *
-   * @param {String} parent  The absolute path for the parent file.
-   * @param {String} child   The absolute path for the dependency file.
-   * @return {File}
+   * @param {String|File} parent  The parent file (or it's string ID).
+   * @param {String|File} child   The child file (or it's string ID).
    */
   addDependency(parent, child) {
-    debug('adding dependency %s -> %s', relative(child), relative(parent));
-    if (!this.hasFile(child)) this.addFile(child);
-    this.graph.addEdge(child, parent);
-    return this.getFile(child);
+    debug('adding dependency %s -> %s', child, parent);
+    this.graph.addEdge(id(child), id(parent));
   }
 
   /**
    * Removes the dependency `child` from the `parent` file.
    *
-   * @param {String} parent  The absolute path for the parent file.
-   * @param {String} child   The absolute path for the dependency file.
+   * @param {String|File} parent  The parent file (or it's string ID).
+   * @param {String|File} child   The child file (or it's string ID).
    */
   removeDependency(parent, child) {
-    debug('removing dependency %s -> %s', relative(child), relative(parent));
-    this.graph.removeEdge(child, parent);
-  }
-
-  /**
-   * Removes all dependencies from the `parent` file.
-   *
-   * @param {String} parent  The absolute path for the parent file.
-   */
-  removeDependencies(parent) {
-    debug('removing all dependencies from %s', relative(parent));
-    this.dependenciesOf(parent)
-      .forEach(child => this.removeDependency(parent, child));
+    debug('removing dependency %s -> %s', child, parent);
+    this.graph.removeEdge(id(child), id(parent));
   }
 
   /**
@@ -207,73 +176,55 @@ class Tree {
    *
    * Available `options`:
    *  - `recursive` when set, go recursively down the entire graph
-   *  - `objects` return the `File` instances
    *
-   * @param {String} node       The absolute path to start from.
+   * @param {String|File} file  The parent file (or it's string ID).
    * @param {Object} [options]  The search criteria.
    * @return {Array}
    */
-  dependenciesOf(node, options) {
-    let config = defaults(options, {
-      recursive: false,
-      objects: false
-    });
-    debug('getting dependencies of %s: %j', relative(node), config);
+  dependenciesOf(file, options) {
+    let config = defaults(options, { recursive: false });
+    debug('getting dependencies of %s: %j', file, config);
 
     let deps = config.recursive
-      ? Array.from(this.graph.verticesWithPathTo(node))
-      : Array.from(this.graph.verticesTo(node));
+      ? Array.from(this.graph.verticesWithPathTo(id(file)))
+      : Array.from(this.graph.verticesTo(id(file)));
 
     debug('%d dependencies found', deps.length);
-    return deps.map(vertices(config.objects));
+    return deps.map(v => v[1]);
   }
 
   /**
    * Checks to see if the given `child` has a link to dependant `parent`.
    *
-   * @param {String} child   The absolute path for the target file.
-   * @param {String} parent  The absolute path for the dependant file.
+   * @param {String|File} child   The child file (or it's string ID).
+   * @param {String|File} parent  The parent file (or it's string ID).
    * @return {Boolean}
    */
   hasDependant(child, parent) {
-    return this.graph.hasEdge(child, parent);
+    return this.graph.hasEdge(id(child), id(parent));
   }
 
   /**
    * Sets up the given `parent` as a dependant of `child`. In other words,
    * the reverse of addDependency()
    *
-   * @param {String} child   The absolute path for the target file.
-   * @param {String} parent  The absolute path for the dependant file.
-   * @return {File}
+   * @param {String|File} child   The child file (or it's string ID).
+   * @param {String|File} parent  The parent file (or it's string ID).
    */
   addDependant(child, parent) {
-    debug('adding dependant %s <- %s', relative(parent), relative(child));
-    if (!this.hasFile(parent)) this.addFile(parent);
-    this.graph.addEdge(child, parent);
-    return this.getFile(parent);
+    debug('adding dependant %s <- %s', parent, child);
+    this.graph.addEdge(id(child), id(parent));
   }
 
   /**
    * Removes the dependant `parent` from the `child` file.
    *
-   * @param {String} child   The absolute path for the target file.
-   * @param {String} parent  The absolute path for the dependant file.
+   * @param {String|File} child   The child file (or it's string ID).
+   * @param {String|File} parent  The parent file (or it's string ID).
    */
   removeDependant(child, parent) {
-    debug('removing dependant %s <- %s', relative(parent), relative(child));
-    this.graph.removeEdge(child, parent);
-  }
-
-  /**
-   * Removes all dependants from the `child` file.
-   *
-   * @param {String} child  The absolute path for the target file.
-   */
-  removeDependants(child) {
-    debug('removing all dependants from %s', relative(child));
-    this.dependantsOf(child)
-      .forEach(parent => this.removeDependant(child, parent));
+    debug('removing dependant %s <- %s', parent, child);
+    this.graph.removeEdge(id(child), id(parent));
   }
 
   /**
@@ -281,25 +232,21 @@ class Tree {
    *
    * Available `options`:
    *  - `recursive` when set, go recursively down the entire graph
-   *  - `objects` return the `File` instances
    *
-   * @param {String} node       The absolute path to start from.
-   * @param {Object} [options]  The search criteria.
+   * @param {String|File} file   The child file (or it's string ID).
+   * @param {Object} [options]   The search criteria.
    * @return {Array}
    */
-  dependantsOf(node, options) {
-    let config = defaults(options, {
-      recursive: false,
-      objects: false
-    });
-    debug('getting dependants of %s: %j', relative(node), config);
+  dependantsOf(file, options) {
+    let config = defaults(options, { recursive: false });
+    debug('getting dependants of %s: %j', file, config);
 
     let deps = config.recursive
-      ? Array.from(this.graph.verticesWithPathFrom(node))
-      : Array.from(this.graph.verticesFrom(node));
+      ? Array.from(this.graph.verticesWithPathFrom(id(file)))
+      : Array.from(this.graph.verticesFrom(id(file)));
 
     debug('%d dependants found', deps.length);
-    return deps.map(vertices(config.objects));
+    return deps.map(v => v[1]);
   }
 
   /**
@@ -342,18 +289,22 @@ class Tree {
     });
 
     files.forEach(file => {
-      if (!deps.has(file)) this.graph.destroyVertex(file);
+      if (!deps.has(file)) this.removeFile(file, { force: true });
     });
 
     debug('done pruning tree');
   }
 
+  /**
+   * Forcibly make this graph acyclic.
+   */
   removeCycles() {
     debug('removing cycles from tree');
-    for (let cycle of this.graph.cycles()) {
-      this.removeDependency(cycle[1], cycle[0]);
-    }
-    debug('done removing cycles from tree');
+    Array.from(this.graph.cycles()).forEach(cycle => {
+      let files = cycle.map(file => this.getFile(file));
+      debug('cycle detected for %s', files.join(' + '));
+      this.removeDependency(files[1], files[0]);
+    });
   }
 
   /**
@@ -364,7 +315,7 @@ class Tree {
    */
   toJSON() {
     return {
-      files: this.getFiles({ objects: true }),
+      files: this.getFiles(),
       dependencies: Array.from(this.graph.edges()).map(e => e.slice(0, 2))
     };
   }
@@ -395,12 +346,12 @@ class Tree {
 
     parsed.files.forEach(o => {
       let file = File.fromObject(o, tree);
-      debug('file from cache', relative(file.path));
-      tree.graph.addNewVertex(file.path, file);
+      debug('file from cache: %s', file.id);
+      tree.graph.addNewVertex(file.id, file);
     });
 
     parsed.dependencies.forEach(e => {
-      debug('dependency from cache: %s', e.map(v => relative(v)).join(' '));
+      debug('dependency from cache: %s', e.join(' '));
       tree.graph.addNewEdge(e[0], e[1]);
     });
 
@@ -415,17 +366,13 @@ module.exports = Tree;
 
 
 /**
- * Helper for mapping a list of vertices. By default, the vertex key (absolute
- * path) is returned, but if `value` is truthy, it will return the `File`
- * object instead.
+ * Helper for retrieving a file id.
  *
- * @param {Boolean} value  Whether to use the key or value.
- * @return {Function}
+ * @param {File|String} file  The file object or a string id.
+ * @return {String}
  */
-function vertices(value) {
-  return function (vertex) {
-    return value ? vertex[1] : vertex[0];
-  };
+function id(file) {
+  return file instanceof File ? file.id : file;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "file-extension": "^2.0.1",
     "graph-toposort": "^0.2.0",
     "graph.js": "^1.20.1",
-    "regex-iso-date": "^1.0.0"
+    "regex-iso-date": "^1.0.0",
+    "uuid": "^2.0.2",
+    "vinyl": "^1.1.1"
   },
   "devDependencies": {
     "@dominicbarnes/eslint-config": "^1.0.0",


### PR DESCRIPTION
In fixing #9, this starts many of the changes mentioned there:

 - The `File` class now extends [vinyl](https://www.npmjs.com/package/vinyl)
    - No longer relying on `file.path` to be immutable, so UUIDs are being generated instead
    - Leveraging the vinyl getters/setters for modifying the path
    - Converting `File#type` into a getter/setter
    - Adding `File#initialPath` and `File#initialType` as getters
 - The `Tree` has been modified as well:
    - Using the aforementioned UUIDs internally, rather than `file.path`
    - Removed `Tree#removeDependencies()` and `Tree#removeDependants()`

All in all, the diff is a net loss of code, which is a huge win in my opinion. Before releasing these changes, I'm going to consider #11 and #12 as they will affect core + plugins greatly too.