### PR TITLE
Removing "entry" from the tree's vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,6 @@
 [![build status](https://img.shields.io/travis/makojs/tree.svg)](https://travis-ci.org/makojs/tree)
 [![coverage](https://img.shields.io/coveralls/makojs/tree.svg)](https://coveralls.io/github/makojs/tree)
 
-## Overview
-
-When working with mako build hooks, the first 2 arguments will be the current `file` and the build
-`tree` respectively. Currently, both of those APIs are contained in this module, as they tightly
-coupled and don't make much sense on their own. (at least at the current time)
-
-Throughout the "analyze" phase, a tree is being built up, starting from the list of entry files.
-Each file being processed adds any direct dependencies, which will then recursively be processed
-to find more dependencies. Each vertex in the graph corresponds to some sort of input file.
-
-During the "build" phase, the tree _may_ be trimmed down, such as the case where the entire
-dependency chain for a JS file will be combined into a single output file. By the end of the build,
-each vertex in the graph corresponds to an output file.
-
 ## API
 
 The `Tree` constructor (documented below) is the primary export for the module. It must be used
@@ -41,7 +27,7 @@ between all the files being tracked.
 
 Returns a `Boolean` reflecting if the given `file` exists in the tree.
 
-### Tree#addFile(params, [entry])
+### Tree#addFile(params)
 
 Creates a file with the given `params` and adds it to the tree.
 
@@ -68,14 +54,6 @@ Removes the given `file` from the tree. It will throw an exception if that file 
 dependency links.
 
 If `options.force` is set, it will forcefully remove the file, as well as any remaining links.
-
-### Tree#getEntries([options])
-
-Returns an `Array` of all the entry files in this graph. (in other words, files that are at the
-end of the dependency chains)
-
-If `options.from` is set, the returned list will only include entries that are reachable from that
-specified file.
 
 ### Tree#hasDependency(parent, child)
 
@@ -132,13 +110,9 @@ Returns the number of files in the tree.
 
 Returns a new `Tree` object that is an effective clone of the original.
 
-### Tree#prune([entries])
+### Tree#prune([anchors])
 
-Removes any orphaned files from the graph. A file is considered orphaned if it has no path to any
-file marked as an entry.
-
-If `entries` is passed, (must be an `Array`) then any files that cannot reach _those_ files will
-be removed from the graph. (essentially overrides the internal list of entries)
+Removes any files from the graph that are unaccessible by any of the provided `anchors` files.
 
 ### Tree#removeCycles()
 
@@ -163,7 +137,7 @@ The `space` parameter is there if you want to "pretty-print" the JSON output.
 Unserializes a JSON string into a `Tree` instance. (see `Tree#toJSON()`)
 
 
-### File(params, tree, [entry]) *(constructor)*
+### File(params, tree) *(constructor)*
 
 This file class extends [vinyl](https://www.npmjs.com/package/vinyl). The `params` will be passed
 directly to that constructor. (except where `params` is a string, then it will be passed as

--- a/lib/file.js
+++ b/lib/file.js
@@ -16,18 +16,16 @@ class File extends Vinyl {
   /**
    * Sets up the instance.
    *
-   * @param {Object} params    The vinyl params for this file.
-   * @param {Tree} tree        The parent build tree.
-   * @param {Boolean} [entry]  If the file is an entry file.
+   * @param {Object} params  The vinyl params for this file.
+   * @param {Tree} tree      The parent build tree.
    */
-  constructor(params, tree, entry) {
+  constructor(params, tree) {
     if (typeof params === 'string') {
       super({ path: params });
     } else {
       super(params);
     }
     this.id = uuid.v4();
-    this.entry = !!entry;
     this.tree = tree;
   }
 
@@ -204,7 +202,7 @@ class File extends Vinyl {
    */
   static fromObject(input, tree) {
     debug('creating file instance from a plain object');
-    let file = new File(input.path, null, input.entry);
+    let file = new File(input.path);
     Object.assign(file, input);
     file.tree = tree;
     debug('done creating file instance');

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -39,13 +39,12 @@ class Tree {
    * Adds the file with the given `params` to the tree. If a file with that
    * path already exists in the tree, that is returned instead.
    *
-   * @param {Object} params    The vinyl params for this file.
-   * @param {Boolean} [entry]  Whether or not this file is an entry.
+   * @param {Object} params  The vinyl params for this file.
    * @return {File}
    */
-  addFile(params, entry) {
-    let file = new File(params, this, entry);
-    debug('adding node: %s (entry: %j)', file, file.entry);
+  addFile(params) {
+    let file = new File(params, this);
+    debug('adding file: %s', file);
     this.graph.addNewVertex(file.id, file);
     return file;
   }
@@ -108,34 +107,6 @@ class Tree {
     } else {
       this.graph.removeVertex(id(file));
     }
-  }
-
-  /**
-   * Retrieve a list of entry file paths based on the given criteria.
-   *
-   * Available `options`:
-   *  - `from` only pull entries that are reachable from this file
-   *
-   * @param {Object} [options]  The filter criteria.
-   * @return {Array}
-   */
-  getEntries(options) {
-    let config = defaults(options, { from: null });
-    debug('getting entry files: %j', config);
-
-    let entries = Array.from(this.graph.sinks())
-      .filter(vertex => !!vertex[1].entry);
-
-    if (config.from) {
-      entries = entries.filter(vertex => {
-        let start = id(config.from);
-        let end = vertex[0];
-        return start === end || this.graph.hasPath(start, end);
-      });
-    }
-
-    debug('%d entries found', entries.length);
-    return entries.map(v => v[1]);
   }
 
   /**
@@ -272,25 +243,25 @@ class Tree {
   }
 
   /**
-   * Remove any files that cannot be reached from the given `entries`.
+   * Remove any files that cannot be reached from the given `anchors`.
    *
-   * @param {Array} [entries]  A list of files to use as the search root.
+   * @param {Array} anchors  A list of files to anchor others to.
    */
-  prune(entries) {
-    debug('pruning orphaned files');
-    if (!entries) entries = this.getEntries();
-    let files = this.getFiles({ topological: true });
+  prune(anchors) {
+    debug('pruning files not accessible from %s', anchors.join(', '));
 
-    let deps = new Set(entries);
-    entries.forEach(entry => {
-      this.dependenciesOf(entry, { recursive: true }).forEach(file => {
+    let deps = new Set();
+    anchors
+      .map(file => this.getFile(id(file)))
+      .forEach(file => {
         deps.add(file);
+        this.dependenciesOf(file, { recursive: true })
+          .forEach(file => deps.add(file));
       });
-    });
 
-    files.forEach(file => {
-      if (!deps.has(file)) this.removeFile(file, { force: true });
-    });
+    this.getFiles({ topological: true })
+      .filter(file => !deps.has(file))
+      .forEach(file => this.removeFile(file, { force: true }));
 
     debug('done pruning tree');
   }

--- a/test/file.js
+++ b/test/file.js
@@ -5,7 +5,7 @@ let assert = require('chai').assert;
 let File = require('../lib/file');
 let Tree = require('../lib/tree');
 
-describe('File(params, tree, [entry])', function () {
+describe('File(params, tree)', function () {
   it('should be a constructor function', function () {
     assert.instanceOf(new File({ path: 'a.js' }), File);
   });
@@ -256,7 +256,6 @@ describe('File(params, tree, [entry])', function () {
       let a = new File('a');
       let actual = a.toJSON();
       assert.strictEqual(actual.path, 'a');
-      assert.isFalse(actual.entry);
     });
 
     it('should preserve custom properties', function () {
@@ -280,7 +279,6 @@ describe('File(params, tree, [entry])', function () {
       assert.instanceOf(actual, File);
       assert.strictEqual(actual.path, 'a.txt');
       assert.strictEqual(actual.type, 'txt');
-      assert.isTrue(actual.entry);
     });
 
     it('should properly handle date objects', function () {


### PR DESCRIPTION
I think the internal tracking on "entry" files is too much of an implementation detail, and core should just use the list it's already keeping to reference those files. Although, I suspect that much of the time you really want to check for root/anchor files on a case-by-case basis. (keeping that notion internally obfuscated atypical cases)