### PR TITLE
add checks to ensure ignore if the file doesn't exist

### DIFF
--- a/lib/tree.js
+++ b/lib/tree.js
@@ -131,6 +131,7 @@ class Tree {
   removeFile (node, options) {
     let force = options ? !!options.force : false
     let file = this.getFile(id(node))
+    if (!file) return
     debug('removing file %s: (force: %j)', utils.relative(file.path), force)
     if (force) {
       this.graph.destroyVertex(file.id)
@@ -201,6 +202,7 @@ class Tree {
     let timer = utils.timer()
     let recursive = options ? !!options.recursive : false
     let file = this.getFile(id(node))
+    if (!file) return []
     debug('getting dependencies of %s: (recursive: %j)', utils.relative(file.path), recursive)
 
     let deps = recursive
@@ -271,6 +273,7 @@ class Tree {
     let timer = utils.timer()
     let recursive = options ? !!options.recursive : false
     let file = this.getFile(id(node))
+    if (!file) return []
     debug('getting dependants of %s: (recursive: %j)', utils.relative(file.path), recursive)
 
     let deps = recursive


### PR DESCRIPTION
Not exactly sure how I ran into this, I believe if I'm removing something in the middle of a chain than I think this it will throw if file is undefined. I'll update with tests if i figure out why this happened :-)
